### PR TITLE
Added gunicorn as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ pytz==2013d
 PyYAML==3.11
 south==1.0
 
+# deploy
+gunicorn
+
 # dev
 flake8==2.2.3
 coverage==3.7.1


### PR DESCRIPTION
Having gunicorn as a requirement ensures it is installed when running from docker compose (WIP)
